### PR TITLE
chore: 컨트롤에서 findItineraries() 메소드 삭제

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -29,8 +29,4 @@ public class TravelController {
         return null;
     }
 
-    public List<ItineraryResponse> findItineraries(Long tripId) {
-        return null;
-    }
-
 }


### PR DESCRIPTION
어플케이션을 기획안과 다르게 바꾸면서 불필요해진 findItineraries() 메소드 삭제
closes #9