### PR TITLE
여행+여정 조회 기능 구현

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-develop:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -2,7 +2,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ maindisable ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,16 @@ jobs:
           tool_name: 'testtool'
           level: error
           checkstyle_config: ./custom_google_checks.xml
+  build_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        with:
+          arguments: build

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'io.rest-assured:rest-assured:5.3.2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/fastcampus/travel/TravelApplication.java
+++ b/src/main/java/kr/co/fastcampus/travel/TravelApplication.java
@@ -2,8 +2,10 @@ package kr.co.fastcampus.travel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TravelApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/co/fastcampus/travel/common/config/AppConfig.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/config/AppConfig.java
@@ -2,6 +2,7 @@ package kr.co.fastcampus.travel.common.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +13,7 @@ public class AppConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.registerModule(new JavaTimeModule());
         return objectMapper;
     }
 }

--- a/src/main/java/kr/co/fastcampus/travel/common/config/AppConfig.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/config/AppConfig.java
@@ -2,6 +2,7 @@ package kr.co.fastcampus.travel.common.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ public class AppConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;
     }
 }

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/EntityNotFoundException.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.co.fastcampus.travel.common.exception;
+
+import kr.co.fastcampus.travel.common.response.ErrorCode;
+
+public class EntityNotFoundException extends BaseException {
+
+    public EntityNotFoundException() {
+        super(ErrorCode.COMMON_ENTITY_NOT_FOUND.getErrorMsg());
+    }
+}

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
@@ -26,11 +26,18 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     public ResponseBody<Void> handleValidException(MethodArgumentNotValidException e) {
-        log.warn("[BaseException] Message = {}", NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        log.warn("[BaseException] Message = {}",
+            NestedExceptionUtils.getMostSpecificCause(e).getMessage());
         BindingResult bindingResult = e.getBindingResult();
         FieldError fieldError = bindingResult.getFieldError();
         if (fieldError != null) {
-            String message = "[Request Error] " + fieldError.getField() + "=" + fieldError.getRejectedValue() + " (" + fieldError.getDefaultMessage() + ")";
+            String message = "[Request Error] "
+                + fieldError.getField()
+                + "="
+                + fieldError.getRejectedValue()
+                + " ("
+                + fieldError.getDefaultMessage()
+                + ")";
             return ResponseBody.fail(message);
         }
         return ResponseBody.fail(e.getMessage());

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
@@ -2,30 +2,44 @@ package kr.co.fastcampus.travel.common.exception.handler;
 
 import kr.co.fastcampus.travel.common.exception.BaseException;
 import kr.co.fastcampus.travel.common.response.ResponseBody;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ResponseStatus(HttpStatus.OK)
     @ExceptionHandler(value = BaseException.class)
     public ResponseBody<Void> handleBaseException(BaseException e) {
+        log.warn("[BaseException] Message = {}", e.getMessage());
         return ResponseBody.fail(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     public ResponseBody<Void> handleValidException(MethodArgumentNotValidException e) {
+        log.warn("[BaseException] Message = {}", NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        BindingResult bindingResult = e.getBindingResult();
+        FieldError fieldError = bindingResult.getFieldError();
+        if (fieldError != null) {
+            String message = "[Request Error] " + fieldError.getField() + "=" + fieldError.getRejectedValue() + " (" + fieldError.getDefaultMessage() + ")";
+            return ResponseBody.fail(message);
+        }
         return ResponseBody.fail(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = Exception.class)
     public ResponseBody<Void> handleUnexpectedException(Exception e) {
+        log.error("[Exception]", e);
         return ResponseBody.error(e.getMessage());
     }
 }

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
@@ -3,39 +3,29 @@ package kr.co.fastcampus.travel.common.exception.handler;
 import kr.co.fastcampus.travel.common.exception.BaseException;
 import kr.co.fastcampus.travel.common.response.ResponseBody;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ResponseStatus(HttpStatus.OK)
     @ExceptionHandler(value = BaseException.class)
-    public ResponseEntity<ResponseBody<Void>> handleBaseException(BaseException e) {
-        return new ResponseEntity<>(
-            ResponseBody.fail(e.getMessage()),
-            HttpStatus.OK
-        );
+    public ResponseBody<Void> handleBaseException(BaseException e) {
+        return ResponseBody.fail(e.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<ResponseBody<Void>> handleValidException(
-        MethodArgumentNotValidException e
-    ) {
-        return new ResponseEntity<>(
-            ResponseBody.fail(e.getMessage()),
-            HttpStatus.BAD_REQUEST
-        );
+    public ResponseBody<Void> handleValidException(MethodArgumentNotValidException e) {
+        return ResponseBody.fail(e.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = Exception.class)
-    public ResponseEntity<ResponseBody<Void>> handleUnexpectedException(
-        Exception e
-    ) {
-        return new ResponseEntity<>(
-            ResponseBody.error(e.getMessage()),
-            HttpStatus.INTERNAL_SERVER_ERROR
-        );
+    public ResponseBody<Void> handleUnexpectedException(Exception e) {
+        return ResponseBody.error(e.getMessage());
     }
 }

--- a/src/main/java/kr/co/fastcampus/travel/common/response/ErrorCode.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/response/ErrorCode.java
@@ -1,0 +1,18 @@
+package kr.co.fastcampus.travel.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
+    ;
+
+
+    private final String errorMsg;
+
+    public String getErrorMsg(Object... arg) {
+        return String.format(errorMsg, arg);
+    }
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -2,6 +2,7 @@ package kr.co.fastcampus.travel.controller;
 
 import static kr.co.fastcampus.travel.controller.util.TravelDtoConverter.toTripResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import kr.co.fastcampus.travel.common.response.ResponseBody;
 import kr.co.fastcampus.travel.controller.response.TripResponse;
 import kr.co.fastcampus.travel.entity.Trip;
@@ -22,6 +23,7 @@ public class TravelController {
     private final TripService tripService;
 
     @GetMapping("/trips/{id}")
+    @Operation(summary = "여정을 포함한 여행 조회")
     public ResponseBody<TripResponse> getTrip(@PathVariable Long id) {
         Trip trip = tripService.findTripById(id);
         return ResponseBody.ok(toTripResponse(trip));

--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -1,5 +1,27 @@
 package kr.co.fastcampus.travel.controller;
 
+import static kr.co.fastcampus.travel.controller.util.EntityToResponseConverter.convertTripToResponse;
+
+import kr.co.fastcampus.travel.common.response.ResponseBody;
+import kr.co.fastcampus.travel.controller.response.TripResponse;
+import kr.co.fastcampus.travel.entity.Trip;
+import kr.co.fastcampus.travel.service.TripService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
 public class TravelController {
 
+    private final TripService tripService;
+
+    @GetMapping("/trips/{id}")
+    public ResponseBody<TripResponse> getTrip(@PathVariable Long id) {
+        Trip trip = tripService.findTripById(id);
+        return ResponseBody.ok(convertTripToResponse(trip));
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -10,10 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class TravelController {
 

--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -1,6 +1,6 @@
 package kr.co.fastcampus.travel.controller;
 
-import static kr.co.fastcampus.travel.controller.util.EntityToResponseConverter.convertTripToResponse;
+import static kr.co.fastcampus.travel.controller.util.TravelDtoConverter.toTripResponse;
 
 import kr.co.fastcampus.travel.common.response.ResponseBody;
 import kr.co.fastcampus.travel.controller.response.TripResponse;
@@ -22,6 +22,6 @@ public class TravelController {
     @GetMapping("/trips/{id}")
     public ResponseBody<TripResponse> getTrip(@PathVariable Long id) {
         Trip trip = tripService.findTripById(id);
-        return ResponseBody.ok(convertTripToResponse(trip));
+        return ResponseBody.ok(toTripResponse(trip));
     }
 }

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/ItineraryResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/ItineraryResponse.java
@@ -1,0 +1,13 @@
+package kr.co.fastcampus.travel.controller.response;
+
+import lombok.Builder;
+
+@Builder
+public record ItineraryResponse(
+        Long id,
+        RouteResponse route,
+        LodgeResponse lodge,
+        StayResponse stay
+) {
+
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/LodgeResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/LodgeResponse.java
@@ -1,0 +1,14 @@
+package kr.co.fastcampus.travel.controller.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record LodgeResponse(
+        String placeName,
+        String address,
+        LocalDateTime checkInAt,
+        LocalDateTime checkOutAt
+) {
+
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/RouteResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/RouteResponse.java
@@ -1,0 +1,17 @@
+package kr.co.fastcampus.travel.controller.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record RouteResponse(
+        String transportation,
+        String departurePlaceName,
+        String departureAddress,
+        String destinationPlaceName,
+        String destinationAddress,
+        LocalDateTime departureAt,
+        LocalDateTime arriveAt
+) {
+
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/StayResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/StayResponse.java
@@ -1,0 +1,14 @@
+package kr.co.fastcampus.travel.controller.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record StayResponse(
+        String placeName,
+        String address,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/TripResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/TripResponse.java
@@ -1,0 +1,16 @@
+package kr.co.fastcampus.travel.controller.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record TripResponse(
+        Long id,
+        String name,
+        LocalDate startAt,
+        LocalDate endAt,
+        List<ItineraryResponse> itineraries
+) {
+
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/response/TripResponse.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/response/TripResponse.java
@@ -10,6 +10,7 @@ public record TripResponse(
         String name,
         LocalDate startAt,
         LocalDate endAt,
+        boolean isForeign,
         List<ItineraryResponse> itineraries
 ) {
 

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/EntityToResponseConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/EntityToResponseConverter.java
@@ -1,0 +1,82 @@
+package kr.co.fastcampus.travel.controller.util;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import kr.co.fastcampus.travel.controller.response.ItineraryResponse;
+import kr.co.fastcampus.travel.controller.response.LodgeResponse;
+import kr.co.fastcampus.travel.controller.response.RouteResponse;
+import kr.co.fastcampus.travel.controller.response.StayResponse;
+import kr.co.fastcampus.travel.controller.response.TripResponse;
+import kr.co.fastcampus.travel.entity.Itinerary;
+import kr.co.fastcampus.travel.entity.Lodge;
+import kr.co.fastcampus.travel.entity.Route;
+import kr.co.fastcampus.travel.entity.Stay;
+import kr.co.fastcampus.travel.entity.Trip;
+
+public class EntityToResponseConverter {
+
+    private EntityToResponseConverter() {
+    }
+
+    public static TripResponse convertTripToResponse(Trip trip) {
+        return TripResponse.builder()
+            .id(trip.getId())
+            .name(trip.getName())
+            .startAt(trip.getStartDate())
+            .endAt(trip.getEndDate())
+            .itineraries(getItineraryResponses(trip))
+            .build();
+    }
+
+    private static List<ItineraryResponse> getItineraryResponses(Trip trip) {
+        return trip.getItineraries().stream()
+            .map(EntityToResponseConverter::convertItineraryToResponse)
+            .collect(Collectors.toList());
+    }
+
+    private static ItineraryResponse convertItineraryToResponse(Itinerary itinerary) {
+        return ItineraryResponse.builder()
+            .id(itinerary.getId())
+            .route(Optional.ofNullable(itinerary.getRoute())
+                .map(EntityToResponseConverter::convertRouteToResponse)
+                .orElse(null))
+            .lodge(Optional.ofNullable(itinerary.getLodge())
+                .map(EntityToResponseConverter::convertLodgeToResponse)
+                .orElse(null))
+            .stay(Optional.ofNullable(itinerary.getStay())
+                .map(EntityToResponseConverter::convertStayToResponse)
+                .orElse(null))
+            .build();
+    }
+
+    private static RouteResponse convertRouteToResponse(Route route) {
+        return RouteResponse.builder()
+            .transportation(route.getTransportation())
+            .departurePlaceName(route.getDeparturePlaceName())
+            .departureAddress(route.getDepartureAddress())
+            .destinationPlaceName(route.getDestinationPlaceName())
+            .destinationAddress(route.getDestinationAddress())
+            .departureAt(route.getDepartureAt())
+            .arriveAt(route.getArriveAt())
+            .build();
+    }
+
+    private static LodgeResponse convertLodgeToResponse(Lodge lodge) {
+        return LodgeResponse.builder()
+            .placeName(lodge.getPlaceName())
+            .address(lodge.getAddress())
+            .checkInAt(lodge.getCheckInAt())
+            .checkOutAt(lodge.getCheckOutAt())
+            .build();
+    }
+
+    private static StayResponse convertStayToResponse(Stay stay) {
+        return StayResponse.builder()
+            .placeName(stay.getPlaceName())
+            .address(stay.getAddress())
+            .startAt(stay.getStartAt())
+            .endAt(stay.getEndAt())
+            .build();
+    }
+}

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
@@ -14,12 +14,12 @@ import kr.co.fastcampus.travel.entity.Route;
 import kr.co.fastcampus.travel.entity.Stay;
 import kr.co.fastcampus.travel.entity.Trip;
 
-public class EntityToResponseConverter {
+public class TravelDtoConverter {
 
-    private EntityToResponseConverter() {
+    private TravelDtoConverter() {
     }
 
-    public static TripResponse convertTripToResponse(Trip trip) {
+    public static TripResponse toTripResponse(Trip trip) {
         return TripResponse.builder()
             .id(trip.getId())
             .name(trip.getName())
@@ -31,26 +31,26 @@ public class EntityToResponseConverter {
 
     private static List<ItineraryResponse> getItineraryResponses(Trip trip) {
         return trip.getItineraries().stream()
-            .map(EntityToResponseConverter::convertItineraryToResponse)
+            .map(TravelDtoConverter::toItieraryResponse)
             .collect(Collectors.toList());
     }
 
-    private static ItineraryResponse convertItineraryToResponse(Itinerary itinerary) {
+    private static ItineraryResponse toItieraryResponse(Itinerary itinerary) {
         return ItineraryResponse.builder()
             .id(itinerary.getId())
             .route(Optional.ofNullable(itinerary.getRoute())
-                .map(EntityToResponseConverter::convertRouteToResponse)
+                .map(TravelDtoConverter::toRouteResponse)
                 .orElse(null))
             .lodge(Optional.ofNullable(itinerary.getLodge())
-                .map(EntityToResponseConverter::convertLodgeToResponse)
+                .map(TravelDtoConverter::toLodgeResponse)
                 .orElse(null))
             .stay(Optional.ofNullable(itinerary.getStay())
-                .map(EntityToResponseConverter::convertStayToResponse)
+                .map(TravelDtoConverter::ToStayResponse)
                 .orElse(null))
             .build();
     }
 
-    private static RouteResponse convertRouteToResponse(Route route) {
+    private static RouteResponse toRouteResponse(Route route) {
         return RouteResponse.builder()
             .transportation(route.getTransportation())
             .departurePlaceName(route.getDeparturePlaceName())
@@ -62,7 +62,7 @@ public class EntityToResponseConverter {
             .build();
     }
 
-    private static LodgeResponse convertLodgeToResponse(Lodge lodge) {
+    private static LodgeResponse toLodgeResponse(Lodge lodge) {
         return LodgeResponse.builder()
             .placeName(lodge.getPlaceName())
             .address(lodge.getAddress())
@@ -71,7 +71,7 @@ public class EntityToResponseConverter {
             .build();
     }
 
-    private static StayResponse convertStayToResponse(Stay stay) {
+    private static StayResponse ToStayResponse(Stay stay) {
         return StayResponse.builder()
             .placeName(stay.getPlaceName())
             .address(stay.getAddress())

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
@@ -25,6 +25,7 @@ public class TravelDtoConverter {
             .name(trip.getName())
             .startAt(trip.getStartDate())
             .endAt(trip.getEndDate())
+            .isForeign(trip.isForeign())
             .itineraries(getItineraryResponses(trip))
             .build();
     }

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
@@ -45,7 +45,7 @@ public class TravelDtoConverter {
                 .map(TravelDtoConverter::toLodgeResponse)
                 .orElse(null))
             .stay(Optional.ofNullable(itinerary.getStay())
-                .map(TravelDtoConverter::ToStayResponse)
+                .map(TravelDtoConverter::toStayResponse)
                 .orElse(null))
             .build();
     }
@@ -71,7 +71,7 @@ public class TravelDtoConverter {
             .build();
     }
 
-    private static StayResponse ToStayResponse(Stay stay) {
+    private static StayResponse toStayResponse(Stay stay) {
         return StayResponse.builder()
             .placeName(stay.getPlaceName())
             .address(stay.getAddress())

--- a/src/main/java/kr/co/fastcampus/travel/entity/Itinerary.java
+++ b/src/main/java/kr/co/fastcampus/travel/entity/Itinerary.java
@@ -1,22 +1,25 @@
 package kr.co.fastcampus.travel.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Itinerary extends BaseEntity {
 
     @Id
-    @Column(name = "itinerary_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -29,6 +32,65 @@ public class Itinerary extends BaseEntity {
     @Embedded
     private Stay stay;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
     private Trip trip;
+
+    @Builder
+    private Itinerary(Route route, Lodge lodge, Stay stay) {
+        this.route = route;
+        this.lodge = lodge;
+        this.stay = stay;
+    }
+
+    @Builder
+    private Itinerary(
+        String transportation,
+        String departurePlaceName,
+        String departureAddress,
+        String destinationPlaceName,
+        String destinationAddress,
+        LocalDateTime departureAt,
+        LocalDateTime arriveAt,
+        String lodgePlaceName,
+        String lodgeAddress,
+        LocalDateTime checkInAt,
+        LocalDateTime checkOutAt,
+        String stayPlaceName,
+        String stayAddress,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+    ) {
+        this.route = Route.builder()
+            .transportation(transportation)
+            .departurePlaceName(departurePlaceName)
+            .departureAddress(departureAddress)
+            .destinationPlaceName(destinationPlaceName)
+            .destinationAddress(destinationAddress)
+            .departureAt(departureAt)
+            .arriveAt(arriveAt)
+            .build();
+
+        this.lodge = Lodge.builder()
+            .placeName(lodgePlaceName)
+            .address(lodgeAddress)
+            .checkInAt(checkInAt)
+            .checkOutAt(checkOutAt)
+            .build();
+
+        this.stay = Stay.builder()
+            .placeName(stayPlaceName)
+            .address(stayAddress)
+            .startAt(startAt)
+            .endAt(endAt)
+            .build();
+    }
+
+    public void registerTrip(Trip trip) {
+        if (this.trip != null) {
+            this.trip.getItineraries().remove(this);
+        }
+        trip.addItinerary(this);
+        this.trip = trip;
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/entity/Lodge.java
+++ b/src/main/java/kr/co/fastcampus/travel/entity/Lodge.java
@@ -3,8 +3,14 @@ package kr.co.fastcampus.travel.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lodge {
 
     @Column(name = "lodge_place_name", length = 100)
@@ -13,4 +19,17 @@ public class Lodge {
     private String address;
     private LocalDateTime checkInAt;
     private LocalDateTime checkOutAt;
+
+    @Builder
+    private Lodge(
+        String placeName,
+        String address,
+        LocalDateTime checkInAt,
+        LocalDateTime checkOutAt
+    ) {
+        this.placeName = placeName;
+        this.address = address;
+        this.checkInAt = checkInAt;
+        this.checkOutAt = checkOutAt;
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/entity/Route.java
+++ b/src/main/java/kr/co/fastcampus/travel/entity/Route.java
@@ -3,21 +3,43 @@ package kr.co.fastcampus.travel.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Route {
 
     @Column(length = 100)
-
     private String transportation;
     @Column(length = 100)
-
     private String departurePlaceName;
     private String departureAddress;
     @Column(length = 100)
-
     private String destinationPlaceName;
     private String destinationAddress;
     private LocalDateTime departureAt;
     private LocalDateTime arriveAt;
+
+    @Builder
+    private Route(
+        String transportation,
+        String departurePlaceName,
+        String departureAddress,
+        String destinationPlaceName,
+        String destinationAddress,
+        LocalDateTime departureAt,
+        LocalDateTime arriveAt
+    ) {
+        this.transportation = transportation;
+        this.departurePlaceName = departurePlaceName;
+        this.departureAddress = departureAddress;
+        this.destinationPlaceName = destinationPlaceName;
+        this.destinationAddress = destinationAddress;
+        this.departureAt = departureAt;
+        this.arriveAt = arriveAt;
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/entity/Stay.java
+++ b/src/main/java/kr/co/fastcampus/travel/entity/Stay.java
@@ -3,8 +3,14 @@ package kr.co.fastcampus.travel.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stay {
 
     @Column(name = "stay_place_name", length = 100)
@@ -13,4 +19,17 @@ public class Stay {
     private String address;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
+
+    @Builder
+    private Stay(
+        String placeName,
+        String address,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+    ) {
+        this.placeName = placeName;
+        this.address = address;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/entity/Trip.java
+++ b/src/main/java/kr/co/fastcampus/travel/entity/Trip.java
@@ -9,17 +9,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Trip extends BaseEntity {
 
     @Id
-    @Column(name = "trip_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -36,8 +38,25 @@ public class Trip extends BaseEntity {
     private boolean isForeign;
 
     @OneToMany(
-        fetch = FetchType.LAZY, mappedBy = "itinerary_id",
-        cascade = CascadeType.ALL, orphanRemoval = true
+        fetch = FetchType.LAZY, mappedBy = "trip",
+        cascade = CascadeType.PERSIST, orphanRemoval = true
     )
-    private List<Itinerary> itineraries;
+    private List<Itinerary> itineraries = new ArrayList<>();
+
+    @Builder
+    private Trip(
+        String name,
+        LocalDate startDate,
+        LocalDate endDate,
+        boolean isForeign
+    ) {
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isForeign = isForeign;
+    }
+
+    public void addItinerary(Itinerary itinerary) {
+        itineraries.add(itinerary);
+    }
 }

--- a/src/main/java/kr/co/fastcampus/travel/repository/TripRepository.java
+++ b/src/main/java/kr/co/fastcampus/travel/repository/TripRepository.java
@@ -1,0 +1,18 @@
+package kr.co.fastcampus.travel.repository;
+
+import java.util.Optional;
+import kr.co.fastcampus.travel.entity.Trip;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface TripRepository extends CrudRepository<Trip, Long> {
+
+    @Query(
+            "select t "
+                    + "from Trip t "
+                    + "join fetch t.itineraries i "
+                    + "where t.id = :id"
+    )
+    Optional<Trip> findFetchItineraryById(@Param("id") Long id);
+}

--- a/src/main/java/kr/co/fastcampus/travel/service/TravelService.java
+++ b/src/main/java/kr/co/fastcampus/travel/service/TravelService.java
@@ -1,5 +1,0 @@
-package kr.co.fastcampus.travel.service;
-
-public class TravelService {
-
-}

--- a/src/main/java/kr/co/fastcampus/travel/service/TripService.java
+++ b/src/main/java/kr/co/fastcampus/travel/service/TripService.java
@@ -1,0 +1,23 @@
+package kr.co.fastcampus.travel.service;
+
+import kr.co.fastcampus.travel.common.exception.EntityNotFoundException;
+import kr.co.fastcampus.travel.entity.Trip;
+import kr.co.fastcampus.travel.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TripService {
+
+    private final TripRepository tripRepository;
+
+    public Trip findTripById(Long id) {
+        return tripRepository.findFetchItineraryById(id)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,17 +4,19 @@ DROP TABLE IF EXISTS `Trip`;
 
 -- Create Trip table
 CREATE TABLE `Trip` (
-    `trip_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(100) NOT NULL,
     `start_date` DATE NOT NULL,
     `end_date` DATE NOT NULL,
     `is_foreign` TINYINT(1) NOT NULL,
-    PRIMARY KEY (`trip_id`)
+    `created_date` TIMESTAMP NOT NULL,
+    `updated_date` TIMESTAMP NULL,
+    PRIMARY KEY (`id`)
 );
 
 -- Create Itinerary table
 CREATE TABLE `Itinerary` (
-    `itinerary_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
     `trip_id` BIGINT NOT NULL,
     -- Embedded Route columns
     `transportation` VARCHAR(255) NULL,
@@ -34,6 +36,8 @@ CREATE TABLE `Itinerary` (
     `stay_address` VARCHAR(255) NULL,
     `start_at` DATETIME NULL,
     `end_at` DATETIME NULL,
-    PRIMARY KEY (`itinerary_id`),
-    FOREIGN KEY (`trip_id`) REFERENCES `Trip`(`trip_id`) ON DELETE CASCADE
+    `created_date` TIMESTAMP NOT NULL,
+    `updated_date` TIMESTAMP NULL,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`trip_id`) REFERENCES `Trip`(`id`) ON DELETE CASCADE
 );

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -40,7 +40,7 @@ class TravelControllerTest {
     @DisplayName("여행과 여정 조회")
     void getTrip() {
         // given
-        String url = "/trips/{id}";
+        String url = "/api/trips/{id}";
         Trip trip = Trip.builder()
             .name("여행")
             .startDate(LocalDate.now())

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -47,7 +47,7 @@ class TravelControllerTest {
             .endDate(LocalDate.now().plusDays(7))
             .build();
 
-        IntStream.range(0,3)
+        IntStream.range(0, 3)
             .forEach(i -> {
                 Itinerary itinerary = Itinerary.builder().build();
                 itinerary.registerTrip(trip);
@@ -58,7 +58,7 @@ class TravelControllerTest {
         // when
         ExtractableResponse<Response> response = RestAssured
             .given().log().all()
-                .pathParams("id", trip.getId())
+            .pathParams("id", trip.getId())
             .when().get(url)
             .then().log().all()
             .extract();

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -1,0 +1,75 @@
+package kr.co.fastcampus.travel.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+import kr.co.fastcampus.travel.common.response.Status;
+import kr.co.fastcampus.travel.entity.Itinerary;
+import kr.co.fastcampus.travel.entity.Trip;
+import kr.co.fastcampus.travel.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class TravelControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("여행과 여정 조회")
+    void getTrip() {
+        // given
+        String url = "/trips/{id}";
+        Trip trip = Trip.builder()
+            .name("여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(7))
+            .build();
+
+        IntStream.range(0,3)
+            .forEach(i -> {
+                Itinerary itinerary = Itinerary.builder().build();
+                itinerary.registerTrip(trip);
+            });
+
+        tripRepository.save(trip);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+                .pathParams("id", trip.getId())
+            .when().get(url)
+            .then().log().all()
+            .extract();
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertAll(
+            () -> assertThat(jsonPath.getString("status")).isEqualTo(Status.SUCCESS.name()),
+            () -> assertThat(jsonPath.getLong("data.id")).isEqualTo(trip.getId()),
+            () -> assertThat(jsonPath.getList("data.itineraries").size()).isEqualTo(3)
+        );
+    }
+}

--- a/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
@@ -27,7 +27,7 @@ class TripRepositoryTest {
             .endDate(LocalDate.now().plusDays(7))
             .build();
 
-        IntStream.range(0,3)
+        IntStream.range(0, 3)
             .forEach(i -> {
                 Itinerary itinerary = Itinerary.builder().build();
                 itinerary.registerTrip(trip);

--- a/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
@@ -9,9 +9,11 @@ import kr.co.fastcampus.travel.entity.Trip;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TripRepositoryTest {
 
     @Autowired

--- a/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
@@ -1,0 +1,46 @@
+package kr.co.fastcampus.travel.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+import kr.co.fastcampus.travel.entity.Itinerary;
+import kr.co.fastcampus.travel.entity.Trip;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class TripRepositoryTest {
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Test
+    @DisplayName("여행 + 여정 조회 검증")
+    void test() {
+        // given
+        Trip trip = Trip.builder()
+            .name("여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(7))
+            .build();
+
+        IntStream.range(0,3)
+            .forEach(i -> {
+                Itinerary itinerary = Itinerary.builder().build();
+                itinerary.registerTrip(trip);
+            });
+
+        tripRepository.save(trip);
+
+        // when
+        Trip result = tripRepository.findFetchItineraryById(trip.getId()).orElse(null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(trip.getId());
+        assertThat(result.getItineraries().size()).isEqualTo(3);
+    }
+}

--- a/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
@@ -3,29 +3,26 @@ package kr.co.fastcampus.travel.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Optional;
 import kr.co.fastcampus.travel.common.exception.EntityNotFoundException;
 import kr.co.fastcampus.travel.entity.Trip;
 import kr.co.fastcampus.travel.repository.TripRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TripServiceTest {
 
     @Mock
     private TripRepository tripRepository;
 
+    @InjectMocks
     private TripService tripService;
-
-    @BeforeEach
-    public void setUp() {
-        openMocks(this);
-        tripService = new TripService(tripRepository);
-    }
 
     @Test
     @DisplayName("여행 + 여정 조회 결과 없음")

--- a/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
@@ -1,0 +1,54 @@
+package kr.co.fastcampus.travel.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.Optional;
+import kr.co.fastcampus.travel.common.exception.EntityNotFoundException;
+import kr.co.fastcampus.travel.entity.Trip;
+import kr.co.fastcampus.travel.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class TripServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    private TripService tripService;
+
+    @BeforeEach
+    public void setUp() {
+        openMocks(this);
+        tripService = new TripService(tripRepository);
+    }
+
+    @Test
+    @DisplayName("여행 + 여정 조회 결과 없음")
+    void findTripById_failureNotFoundException() {
+        // given
+        when(tripRepository.findFetchItineraryById(-1L)).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> tripService.findTripById(-1L))
+            .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("여행 + 여정 조회")
+    void findTripById_success() {
+        // given
+        when(tripRepository.findFetchItineraryById(-1L)).thenReturn(Optional.of(Trip.builder().build()));
+
+        // when
+        Trip result = tripService.findTripById(-1L);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
@@ -40,7 +40,8 @@ class TripServiceTest {
     @DisplayName("여행 + 여정 조회")
     void findTripById_success() {
         // given
-        when(tripRepository.findFetchItineraryById(-1L)).thenReturn(Optional.of(Trip.builder().build()));
+        when(tripRepository.findFetchItineraryById(-1L))
+            .thenReturn(Optional.of(Trip.builder().build()));
 
         // when
         Trip result = tripService.findTripById(-1L);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=MYSQL
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    database-platform: H2
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
#9 

여행 + 여정 조회입니다.
Jpa는 Fetch Join을 사용해서 Trip을 조회할 때, Itinerary로 함께 Join해서 가져왔습니다.

기존 수정사항
- 엔티티에 모든 생성자 접근제어자는 Private으로 설정하고, Builder를 통해 생성할 수 있도록 수정했습니다.
- GlobalExceptionHandler의 응답 Status는 어노테이션을 활용하도록 수정했습니다.
- 통합테스트를 위함 RestAssured 라이브러리 의존성을 추가했습니다.
- ObjectMapper에서 LocalDate를 인식할 수 있도록 모듈을 추가했습니다.

이외에 궁금한 부분이나 수정이 필요한 부분은 코멘트 주시면 수정해서 반영하겠습니다!
