### PR TITLE
여행 + 여정 조회 시 여정이 없으면 조회하지 못하는 이슈

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/repository/TripRepository.java
+++ b/src/main/java/kr/co/fastcampus/travel/repository/TripRepository.java
@@ -11,7 +11,7 @@ public interface TripRepository extends CrudRepository<Trip, Long> {
     @Query(
         "select t "
             + "from Trip t "
-            + "join fetch t.itineraries i "
+            + "left join fetch t.itineraries i "
             + "where t.id = :id"
     )
     Optional<Trip> findFetchItineraryById(@Param("id") Long id);

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -77,8 +77,39 @@ public class TravelControllerTest {
     }
 
     @Test
-    @DisplayName("여행과 여정 조회")
-    void getTrip() {
+    @DisplayName("여정 없는 여행 조회")
+    void getOnlyTrip() {
+        // given
+        String url = "/api/trips/{id}";
+        Trip trip = Trip.builder()
+            .name("여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(7))
+            .build();
+
+        tripRepository.save(trip);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .pathParams("id", trip.getId())
+            .when().get(url)
+            .then().log().all()
+            .extract();
+
+        // then
+        JsonPath jsonPath = response.jsonPath();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertAll(
+            () -> assertThat(jsonPath.getString("status")).isEqualTo(Status.SUCCESS.name()),
+            () -> assertThat(jsonPath.getLong("data.id")).isEqualTo(trip.getId()),
+            () -> assertThat(jsonPath.getList("data.itineraries").size()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    @DisplayName("여정 포함 여행 조회")
+    void getContainTrip() {
         // given
         String url = "/api/trips/{id}";
         Trip trip = Trip.builder()

--- a/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/repository/TripRepositoryTest.java
@@ -21,7 +21,7 @@ class TripRepositoryTest {
 
     @Test
     @DisplayName("여행 + 여정 조회 검증")
-    void test() {
+    void findContainTrip() {
         // given
         Trip trip = Trip.builder()
             .name("여행")
@@ -44,5 +44,26 @@ class TripRepositoryTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(trip.getId());
         assertThat(result.getItineraries().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("여정 없는 여행 조회 검증")
+    void findOnlyTrip() {
+        // given
+        Trip trip = Trip.builder()
+            .name("여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(7))
+            .build();
+
+        tripRepository.save(trip);
+
+        // when
+        Trip result = tripRepository.findFetchItineraryById(trip.getId()).orElse(null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(trip.getId());
+        assertThat(result.getItineraries().size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
#27
Fetch Join의 기본 방식이 LEFT OUTER JOIN으로 착각했습니다.
기본 방식은 **INNER JOIN** 입니다!!

쿼리에 `left`를 추가하는 방식으로 이슈를 해결하였습니다.