### PR TITLE
TripRequest 검증 오류메시지 출력 잘 되게끔 수정

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/controller/request/TripRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/request/TripRequest.java
@@ -3,21 +3,20 @@ package kr.co.fastcampus.travel.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
 import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Builder
 public record TripRequest(
     @NotBlank
     String name,
     @NotNull
-    @Pattern(regexp = "^(\\d{4}-\\d{2}-\\d{2})$", message = "날짜 형식은 yyyy-MM-dd 여야 합니다.")
-    String startDate,
+    LocalDate startDate,
     @NotNull
-    @Pattern(regexp = "^(\\d{4}-\\d{2}-\\d{2})$", message = "날짜 형식은 yyyy-MM-dd 여야 합니다.")
-    String endDate,
+    LocalDate endDate,
     @NotNull
-    @Pattern(regexp = "true|false", message = "값은 true 또는 false 여야 합니다.")
-    boolean isForeign
+    Boolean isForeign
 ) {
 
 }

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
@@ -52,8 +52,8 @@ public class TravelDtoConverter {
     public static Trip toTrip(TripRequest request) {
         return Trip.builder()
             .name(request.name())
-            .startDate(LocalDate.parse(request.startDate()))
-            .endDate(LocalDate.parse(request.endDate()))
+            .startDate(request.startDate())
+            .endDate(request.endDate())
             .isForeign(request.isForeign())
             .build();
     }

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -39,7 +39,9 @@ public class TravelControllerTest extends ApiTest {
         // given
         String url = "/api/trips";
         TripRequest request = new TripRequest(
-            "이름", "2010-01-01", "2010-01-02", false
+            "이름",
+            LocalDate.parse("2010-01-01"), LocalDate.parse("2010-01-02"),
+            false
         );
 
         // when


### PR DESCRIPTION
## 수정 전

### endDate (startDate)에 null이 들어올 때

<img width="446" alt="기존_null일때" src="https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/33937365/1629e73d-0535-4a67-b36d-fc99665b3249">

의미를 알기 힘든 에러메시지

### isForeign에 null이 들어올 때

<img width="635" alt="image" src="https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/33937365/1cfb0bee-dcd8-41f2-90c2-6d23af247c73">

에러메시지 없이 자기 맘대로 false로 처리함

## 수정 후

### endDate (startDate)에 null이 들어올 때

<img width="969" alt="image" src="https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/33937365/bb883bf5-6bd0-4d96-bc6d-c675b1685c17">

### isForeign에 null이 들어올 때

<img width="984" alt="image" src="https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/33937365/e054aa2e-8bc9-4912-97d3-d131fa19a83b">
