### PR TITLE
여행 삭제 구현

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/TravelController.java
@@ -95,6 +95,13 @@ public class TravelController {
         return ResponseBody.ok(response);
     }
 
+    @DeleteMapping("/trips/{id}")
+    @Operation(summary = "여행 삭제")
+    public ResponseBody<Void> deleteTrip(@PathVariable Long id) {
+        tripService.deleteTrip(id);
+        return ResponseBody.ok();
+    }
+
     @DeleteMapping("/itineraries/{itineraryId}")
     @Operation(summary = "여정 삭제")
     public ResponseBody<Void> deleteItinerary(@PathVariable Long itineraryId) {

--- a/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
+++ b/src/main/java/kr/co/fastcampus/travel/controller/util/TravelDtoConverter.java
@@ -3,7 +3,6 @@ package kr.co.fastcampus.travel.controller.util;
 import static java.util.Objects.isNull;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import kr.co.fastcampus.travel.controller.request.ItineraryRequest;
 import kr.co.fastcampus.travel.controller.request.LodgeRequest;
@@ -80,15 +79,9 @@ public class TravelDtoConverter {
     public static ItineraryResponse toItineraryResponse(Itinerary itinerary) {
         return ItineraryResponse.builder()
             .id(itinerary.getId())
-            .route(Optional.ofNullable(itinerary.getRoute())
-                .map(TravelDtoConverter::toRouteResponse)
-                .orElse(null))
-            .lodge(Optional.ofNullable(itinerary.getLodge())
-                .map(TravelDtoConverter::toLodgeResponse)
-                .orElse(null))
-            .stay(Optional.ofNullable(itinerary.getStay())
-                .map(TravelDtoConverter::toStayResponse)
-                .orElse(null))
+            .route(toRouteResponse(itinerary.getRoute()))
+            .lodge(toLodgeResponse(itinerary.getLodge()))
+            .stay(toStayResponse(itinerary.getStay()))
             .build();
     }
 
@@ -135,6 +128,10 @@ public class TravelDtoConverter {
     }
 
     private static RouteResponse toRouteResponse(Route route) {
+        if (isNull(route)) {
+            return null;
+        }
+
         return RouteResponse.builder()
             .transportation(route.getTransportation())
             .departurePlaceName(route.getDeparturePlaceName())
@@ -147,6 +144,10 @@ public class TravelDtoConverter {
     }
 
     private static LodgeResponse toLodgeResponse(Lodge lodge) {
+        if (isNull(lodge)) {
+            return null;
+        }
+
         return LodgeResponse.builder()
             .placeName(lodge.getPlaceName())
             .address(lodge.getAddress())
@@ -156,6 +157,10 @@ public class TravelDtoConverter {
     }
 
     private static StayResponse toStayResponse(Stay stay) {
+        if (isNull(stay)) {
+            return null;
+        }
+
         return StayResponse.builder()
             .placeName(stay.getPlaceName())
             .address(stay.getAddress())

--- a/src/main/java/kr/co/fastcampus/travel/service/TripService.java
+++ b/src/main/java/kr/co/fastcampus/travel/service/TripService.java
@@ -49,4 +49,10 @@ public class TripService {
 
         return tripRepository.save(trip);
     }
+
+    @Transactional
+    public void deleteTrip(Long id) {
+        Trip trip = findById(id);
+        tripRepository.delete(trip);
+    }
 }

--- a/src/test/java/kr/co/fastcampus/travel/TravelTestUtils.java
+++ b/src/test/java/kr/co/fastcampus/travel/TravelTestUtils.java
@@ -152,10 +152,9 @@ public class TravelTestUtils {
             .extract();
     }
 
-    public static ExtractableResponse<Response> requestDeleteItineraryApi(Long id, String url) {
+    public static ExtractableResponse<Response> requestDeleteApi(String url) {
         return RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .pathParams("itineraryId", id)
             .when().delete(url)
             .then().log().all()
             .extract();

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -7,7 +7,7 @@ import static kr.co.fastcampus.travel.TravelTestUtils.createRouteRequest;
 import static kr.co.fastcampus.travel.TravelTestUtils.createStayRequest;
 import static kr.co.fastcampus.travel.TravelTestUtils.createTrip;
 import static kr.co.fastcampus.travel.TravelTestUtils.putAndExtractResponse;
-import static kr.co.fastcampus.travel.TravelTestUtils.requestDeleteItineraryApi;
+import static kr.co.fastcampus.travel.TravelTestUtils.requestDeleteApi;
 import static kr.co.fastcampus.travel.TravelTestUtils.requestFindAllTripApi;
 import static kr.co.fastcampus.travel.controller.util.TravelDtoConverter.toTripSummaryResponse;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -305,8 +305,8 @@ public class TravelControllerTest extends ApiTest {
         Itinerary itinerary = saveItinerary(trip);
 
         //when
-        String url = "/api/itineraries/{itineraryId}";
-        requestDeleteItineraryApi(itinerary.getId(), url);
+        String url = "/api/itineraries/" + itinerary.getId();
+        requestDeleteApi(url);
 
         //then
         Trip findTrip = tripRepository.findFetchItineraryById(trip.getId()).get();
@@ -323,8 +323,8 @@ public class TravelControllerTest extends ApiTest {
         saveItinerary(trip);
 
         //when
-        String url = "/api/itineraries/{itineraryId}";
-        ExtractableResponse<Response> response = requestDeleteItineraryApi(5L, url);
+        String url = "/api/itineraries/5";
+        ExtractableResponse<Response> response = requestDeleteApi(url);
 
         //then
         assertSoftly(softly -> {

--- a/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/controller/TravelControllerTest.java
@@ -9,6 +9,8 @@ import static kr.co.fastcampus.travel.TravelTestUtils.createTrip;
 import static kr.co.fastcampus.travel.TravelTestUtils.putAndExtractResponse;
 import static kr.co.fastcampus.travel.TravelTestUtils.requestDeleteApi;
 import static kr.co.fastcampus.travel.TravelTestUtils.requestFindAllTripApi;
+import static kr.co.fastcampus.travel.common.response.Status.FAIL;
+import static kr.co.fastcampus.travel.common.response.Status.SUCCESS;
 import static kr.co.fastcampus.travel.controller.util.TravelDtoConverter.toTripSummaryResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -294,6 +296,37 @@ public class TravelControllerTest extends ApiTest {
             softly.assertThat(data.name()).isEqualTo("tripName");
             softly.assertThat(data.itineraries().size()).isEqualTo(3);
         });
+    }
+
+    @Test
+    @DisplayName("없는 여행 삭제")
+    void deleteTrip_failureException() {
+        //given
+        String url = "/api/trips/-1";
+
+        //when
+        ExtractableResponse<Response> response = requestDeleteApi(url);
+
+        //then
+        JsonPath jsonPath = response.jsonPath();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(jsonPath.getString("status")).isEqualTo(FAIL.name());
+    }
+
+    @Test
+    @DisplayName("여행 삭제")
+    void deleteTrip() {
+        //given
+        Trip trip = saveTrip();
+        String url = "/api/trips/" + trip.getId();
+
+        //when
+        ExtractableResponse<Response> response = requestDeleteApi(url);
+
+        //then
+        JsonPath jsonPath = response.jsonPath();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(jsonPath.getString("status")).isEqualTo(SUCCESS.name());
     }
 
     @Test

--- a/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/service/TripServiceTest.java
@@ -125,4 +125,17 @@ class TripServiceTest {
         assertThatThrownBy(() -> tripService.editTrip(notExistingTripId, request))
             .isInstanceOf(EntityNotFoundException.class);
     }
+
+    @Test
+    @DisplayName("없는 여행을 삭제하면 예외")
+    void findById_failure() {
+        // given
+        when(tripRepository.findById(-1L))
+            .thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> tripService.deleteTrip(-1L))
+            .isInstanceOf(EntityNotFoundException.class);
+    }
 }


### PR DESCRIPTION
#11

여행 삭제 기능입니다.
별 로직이 없습니다!

#### 추가로 여행 삭제 시, orphanRemoval 옵션을 통해 하위 여정들도 함께 삭제됩니다!

### 추가 변경사항

- Convertor에서 박싱, 언박싱 이슈로 Optional은 삭제했습니다.
  -  Null 체크를 통해 null을 반환하도록 수정하였습니다.

- 통합 테스트 Delete API 요청 메서드 범용성을 위해 url을 파라미터로 받도록 수정했습니다.
