### PR TITLE
검증 실패 시 에러 메시지를 지정 (순서보장까지)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured:5.3.2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
@@ -39,14 +39,15 @@ public class GlobalExceptionHandler {
         BindingResult bindingResult = e.getBindingResult();
         List<FieldError> fieldErrors = getSortedFieldErrors(bindingResult);
 
-        String sb = "[Request error] "
+        String response = "[Request error] "
             + fieldErrors.stream()
-            .map(fieldError
-                -> fieldError.getDefaultMessage()
-                + " (" + fieldError.getField() + "=" + fieldError.getRejectedValue() + ")"
-            )
-            .collect(Collectors.joining(", "));
-        return ResponseBody.fail(sb);
+            .map(fieldError -> String.format("%s (%s=%s)",
+                fieldError.getDefaultMessage(),
+                fieldError.getField(),
+                fieldError.getRejectedValue()
+                )
+            ).collect(Collectors.joining());
+        return ResponseBody.fail(response);
     }
 
     private List<FieldError> getSortedFieldErrors(BindingResult bindingResult) {

--- a/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/exception/handler/GlobalExceptionHandler.java
@@ -1,11 +1,11 @@
 package kr.co.fastcampus.travel.common.exception.handler;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.lang.reflect.Field;
 import kr.co.fastcampus.travel.common.exception.BaseException;
 import kr.co.fastcampus.travel.common.response.ResponseBody;
 import lombok.extern.slf4j.Slf4j;
@@ -41,11 +41,11 @@ public class GlobalExceptionHandler {
 
         String sb = "[Request error] "
             + fieldErrors.stream()
-                .map(fieldError
-                    -> fieldError.getDefaultMessage() +
-                    " (" + fieldError.getField() + "=" + fieldError.getRejectedValue() + ")"
-                )
-                .collect(Collectors.joining(", "));
+            .map(fieldError
+                -> fieldError.getDefaultMessage()
+                + " (" + fieldError.getField() + "=" + fieldError.getRejectedValue() + ")"
+            )
+            .collect(Collectors.joining(", "));
         return ResponseBody.fail(sb);
     }
 

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/LodgeSaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/LodgeSaveRequest.java
@@ -1,9 +1,15 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.save;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record LodgeSaveRequest(
+        @NotBlank(message = "placeName을 입력해주세요.")
+        @Size(max = 100, message = "placeName은 최대 100자입니다.")
         String placeName,
+        @NotBlank(message = "address를 입력해주세요.")
+        @Size(max = 200, message = "address는 최대 200자입니다.")
         String address,
         LocalDateTime checkInAt,
         LocalDateTime checkOutAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/RouteSaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/RouteSaveRequest.java
@@ -1,12 +1,24 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.save;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record RouteSaveRequest(
+        @NotBlank(message = "transporation을 입력해주세요.")
+        @Size(max = 100, message = "transportation은 최대 100자입니다.")
         String transportation,
+        @NotBlank(message = "departurePlaceName을 입력해주세요.")
+        @Size(max = 100, message = "transporation은 최대 100자입니다.")
         String departurePlaceName,
+        @NotBlank(message = "departureAddress를 입력해주세요.")
+        @Size(max = 200, message = "departureAddress는 최대 200자입니다.")
         String departureAddress,
+        @NotBlank(message = "destinationPlaceName을 입력해주세요.")
+        @Size(max = 100, message = "destinationPlaceName은 최대 100자입니다.")
         String destinationPlaceName,
+        @NotBlank(message = "destinationAddress를 입력해주세요.")
+        @Size(max = 200, message = "destinationAddress는 최대 200자입니다.")
         String destinationAddress,
         LocalDateTime departureAt,
         LocalDateTime arriveAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/StaySaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/save/StaySaveRequest.java
@@ -1,9 +1,15 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.save;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record StaySaveRequest(
+        @NotBlank(message = "placeName을 입력해주세요.")
+        @Size(max = 100, message = "placeName은 최대 100자입니다.")
         String placeName,
+        @NotBlank(message = "address를 입력해주세요.")
+        @Size(max = 200, message = "address는 최대 200자입니다.")
         String address,
         LocalDateTime startAt,
         LocalDateTime endAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/LodgeUpdateRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/LodgeUpdateRequest.java
@@ -1,9 +1,15 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.update;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record LodgeUpdateRequest(
+        @NotBlank(message = "placeName을 입력해주세요.")
+        @Size(max = 100, message = "placeName은 최대 100자입니다.")
         String placeName,
+        @NotBlank(message = "address를 입력해주세요.")
+        @Size(max = 200, message = "address는 최대 200자입니다.")
         String address,
         LocalDateTime checkInAt,
         LocalDateTime checkOutAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/RouteUpdateRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/RouteUpdateRequest.java
@@ -1,12 +1,24 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.update;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record RouteUpdateRequest(
+        @NotBlank(message = "transporation을 입력해주세요.")
+        @Size(max = 100, message = "transportation은 최대 100자입니다.")
         String transportation,
+        @NotBlank(message = "departurePlaceName을 입력해주세요.")
+        @Size(max = 100, message = "transporation은 최대 100자입니다.")
         String departurePlaceName,
+        @NotBlank(message = "departureAddress를 입력해주세요.")
+        @Size(max = 200, message = "departureAddress는 최대 200자입니다.")
         String departureAddress,
+        @NotBlank(message = "destinationPlaceName을 입력해주세요.")
+        @Size(max = 100, message = "destinationPlaceName은 최대 100자입니다.")
         String destinationPlaceName,
+        @NotBlank(message = "destinationAddress를 입력해주세요.")
+        @Size(max = 200, message = "destinationAddress는 최대 200자입니다.")
         String destinationAddress,
         LocalDateTime departureAt,
         LocalDateTime arriveAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/StayUpdateRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/itinerary/controller/dto/request/update/StayUpdateRequest.java
@@ -1,9 +1,16 @@
 package kr.co.fastcampus.travel.domain.itinerary.controller.dto.request.update;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record StayUpdateRequest(
+        @NotBlank(message = "placeName을 입력해주세요.")
+        @Size(max = 100, message = "placeName은 최대 100자입니다.")
         String placeName,
+        @NotBlank(message = "address를 입력해주세요.")
+        @Size(max = 200, message = "address는 최대 200자입니다.")
         String address,
         LocalDateTime startAt,
         LocalDateTime endAt

--- a/src/main/java/kr/co/fastcampus/travel/domain/member/controller/dto/request/MemberSaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/member/controller/dto/request/MemberSaveRequest.java
@@ -1,8 +1,8 @@
 package kr.co.fastcampus.travel.domain.member.controller.dto.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record MemberSaveRequest(
         @NotBlank(message = "이메일은 필수 입력 사항입니다.")
@@ -16,7 +16,7 @@ public record MemberSaveRequest(
         String nickname,
 
         @NotBlank(message = "패스워드는 필수 입력 사항입니다.")
-        @Min(value = 8, message = "8자리 이상의 비밀번호를 입력해 주세요")
+        @Size(min = 8, message = "8자리 이상의 비밀번호를 입력해 주세요")
         String password
 ) {
 

--- a/src/main/java/kr/co/fastcampus/travel/domain/trip/controller/dto/request/TripSaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/trip/controller/dto/request/TripSaveRequest.java
@@ -5,13 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record TripSaveRequest(
-    @NotBlank
+    @NotBlank(message = "name은 필수로 입력하셔야 합니다.")
     String name,
-    @NotNull
+    @NotNull(message = "startDate는 필수로 입력하셔야 합니다.")
     LocalDate startDate,
-    @NotNull
+    @NotNull(message = "endDate는 필수로 입력하셔야 합니다.")
     LocalDate endDate,
-    @NotNull
+    @NotNull(message = "isForeign은 필수로 입력하셔야 합니다.")
     Boolean isForeign
 ) {
 

--- a/src/main/java/kr/co/fastcampus/travel/domain/trip/controller/dto/request/TripUpdateRequest.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/trip/controller/dto/request/TripUpdateRequest.java
@@ -1,11 +1,17 @@
 package kr.co.fastcampus.travel.domain.trip.controller.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record TripUpdateRequest(
+    @NotBlank(message = "name은 필수로 입력하셔야 합니다.")
     String name,
+    @NotNull(message = "startDate는 필수로 입력하셔야 합니다.")
     LocalDate startDate,
+    @NotNull(message = "endDate는 필수로 입력하셔야 합니다.")
     LocalDate endDate,
+    @NotNull(message = "isForeign은 필수로 입력하셔야 합니다.")
     Boolean isForeign
 ) {
 

--- a/src/main/java/kr/co/fastcampus/travel/domain/trip/service/dto/request/TripSaveDto.java
+++ b/src/main/java/kr/co/fastcampus/travel/domain/trip/service/dto/request/TripSaveDto.java
@@ -9,7 +9,7 @@ public record TripSaveDto(
     String name,
     LocalDate startDate,
     LocalDate endDate,
-    Boolean isForeign
+    boolean isForeign
 ) {
 
     public Trip toEntity() {

--- a/src/test/java/kr/co/fastcampus/travel/common/MemberTestUtils.java
+++ b/src/test/java/kr/co/fastcampus/travel/common/MemberTestUtils.java
@@ -6,7 +6,7 @@ import kr.co.fastcampus.travel.domain.member.service.dto.request.MemberSaveDto;
 
 public final class MemberTestUtils {
 
-    public static final String EMAIL = "email";
+    public static final String EMAIL = "email@email.com";
     public static final String NAME = "name";
     public static final String NICKNAME = "nickname";
     public static final String PASSWORD = "password";


### PR DESCRIPTION
closes #51 

## 개요

<img width="868" alt="image" src="https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/33937365/828c0e68-cfd2-4284-b5c7-6f0d61f9c56c">

- jakarta.validation Gradle 디펜던시 추가함
- 필드 Validation 실패 시 에러 메시지 형식 조금 바꿈
   - 기존: {fieldName}={fieldValue} ({errorMessage})
   - 변경 후: {errorMessage} ({fieldName}={fieldValue})
- Reflection을 이용해서 클래스에 선언된 필드 순서대로 에러를 뿜도록 함
- 기타 미흡한 Validation 가진 Request DTO들에 Validation 추가함
- 리뷰하실 때 참고
  - GlobalExceptionHandler만 중점적으로 리뷰해주시면 될 것 같습니다. 그 외의 파일에는 자잘한 변경사항만 있습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [X] 새로운 기능 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)