### PR TITLE
Swagger 경로 Spring Security에 추가

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/common/secure/config/SecurityConfig.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/secure/config/SecurityConfig.java
@@ -60,6 +60,15 @@ public class SecurityConfig {
                     new AntPathRequestMatcher("/api/trips/search-by-trip-name",
                         HttpMethod.GET.name())
                 ).permitAll()
+                .requestMatchers(
+                    new AntPathRequestMatcher("/swagger-ui.html")
+                ).permitAll()
+                .requestMatchers(
+                    new AntPathRequestMatcher("/swagger-ui/**")
+                ).permitAll()
+                .requestMatchers(
+                    new AntPathRequestMatcher("/v3/api-docs/**")
+                ).permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .anyRequest().authenticated())
         ;


### PR DESCRIPTION
## 개요
closes #137 
![401에러](https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/95916780/e86ef886-b8a6-4b29-b917-b0d291eda050)
기존 코드로 swagger 접속하면 401 에러가 떠서 swagger 경로를 permitAll 처리했습니다.
![swagger](https://github.com/FC-BE-ToyProject-Team8/TravelApp/assets/95916780/7375d1a5-e292-49c6-9cdd-75b2b3d0b356)


## PR 유형
어떤 변경 사항이 있나요?
- [X] 버그 수정
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)