### PR TITLE
여행 목록 조회 관련 2가지 수정

### DIFF
--- a/src/main/java/kr/co/fastcampus/travel/common/secure/config/SecurityConfig.java
+++ b/src/main/java/kr/co/fastcampus/travel/common/secure/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.co.fastcampus.travel.common.secure.config;
 
+import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import java.util.Arrays;
 import kr.co.fastcampus.travel.common.secure.config.handler.TokenAccessDeniedHandler;
 import kr.co.fastcampus.travel.common.secure.config.handler.TokenAuthenticationEntryPoint;
@@ -8,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,10 +25,12 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
-    private static final String[] WHITELIST_URLS = {
+    private static final String[] WHITELIST_FOR_ALL_METHOD = {
         "/api/login", "/api/signup", "/api/reissue",
-        "/api/search-place", "/api/trips", "/api/trips/search-by-trip-name",
         "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**"
+    };
+    private static final String[] WHITELIST_FOR_GET_METHOD = {
+        "/api/trips", "/api/search-place", "/api/trips/search-by-trip-name"
     };
 
     @Bean
@@ -48,8 +50,15 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
-                    Arrays.stream(WHITELIST_URLS)
+                    Arrays.stream(WHITELIST_FOR_ALL_METHOD)
                         .map(AntPathRequestMatcher::new)
+                        .toArray(AntPathRequestMatcher[]::new)
+                ).permitAll()
+                .requestMatchers(
+                    Arrays.stream(WHITELIST_FOR_GET_METHOD)
+                        .map(
+                            whitelist -> new AntPathRequestMatcher(whitelist, HttpMethod.GET.name())
+                        )
                         .toArray(AntPathRequestMatcher[]::new)
                 ).permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()

--- a/src/test/java/kr/co/fastcampus/travel/common/RestAssuredUtils.java
+++ b/src/test/java/kr/co/fastcampus/travel/common/RestAssuredUtils.java
@@ -20,6 +20,14 @@ public final class RestAssuredUtils {
             .extract();
     }
 
+    public static ExtractableResponse<Response> restAssuredGet(String url) {
+        return restAssured()
+            .when()
+            .get(url)
+            .then().log().all()
+            .extract();
+    }
+
     public static ExtractableResponse<Response> restAssuredGetWithToken(String url) {
         String accessToken = TokenUtils.getAccessToken();
 

--- a/src/test/java/kr/co/fastcampus/travel/domain/trip/controller/TripControllerGetTripTest.java
+++ b/src/test/java/kr/co/fastcampus/travel/domain/trip/controller/TripControllerGetTripTest.java
@@ -1,6 +1,6 @@
 package kr.co.fastcampus.travel.domain.trip.controller;
 
-import static kr.co.fastcampus.travel.common.RestAssuredUtils.restAssuredGetWithToken;
+import static kr.co.fastcampus.travel.common.RestAssuredUtils.restAssuredGet;
 import static kr.co.fastcampus.travel.common.RestAssuredUtils.restAssuredPostWithToken;
 import static kr.co.fastcampus.travel.common.TravelTestUtils.API_TRIPS_ENDPOINT;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -37,7 +37,7 @@ class TripControllerGetTripTest extends ApiTest {
         restAssuredPostWithToken(API_TRIPS_ENDPOINT, request);
 
         // when
-        ExtractableResponse<Response> response = restAssuredGetWithToken(API_TRIPS_ENDPOINT);
+        ExtractableResponse<Response> response = restAssuredGet(API_TRIPS_ENDPOINT);
 
         // then
         JsonPath jsonPath = response.jsonPath();


### PR DESCRIPTION
## 개요

- 여행 목록 조회는 `GET` 메서드만 허용하도록 SecurityConfig 변경
- 컨트롤러 테스트 시 로그인 하지 않고 테스트하도록 변경

## PR 유형
어떤 변경 사항이 있나요?
- [X] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)